### PR TITLE
OGPの基本的な設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,8 @@
     <meta property="og:type" content="website">
     <meta property="og:url" content="<%= request.original_url %>">
     <meta property="og:image" content="<%= asset_path('emblem.png') %>">
-    <meta property="og:site_name" content="サイト名">
-    <meta property="og:description" content="ここにページの説明文を記入します。">
+    <meta property="og:site_name" content="GameAward">
+    <meta property="og:description" content="お気に入りゲームを受賞させよう">
     <meta name="twitter:card" content="summary_large_image"> <!-- Twitter用の設定 -->
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,14 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+
+    <meta property="og:title" content="<%= page_title(yield(:title)) %>">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="<%= request.original_url %>">
+    <meta property="og:image" content="<%= asset_path('emblem.png') %>">
+    <meta property="og:site_name" content="サイト名">
+    <meta property="og:description" content="ここにページの説明文を記入します。">
+    <meta name="twitter:card" content="summary_large_image"> <!-- Twitter用の設定 -->
   </head>
 
   <body class="w-auto">


### PR DESCRIPTION
## 概要

![image](https://github.com/user-attachments/assets/02af45dd-d5b8-4065-b8b3-d549b26ad192)

## 実装内容
- [x] OGPの設定　(ページのタイトル)
- [x] OGPを設定　(コンテンツのタイプ)
- [x] OGPを設定　(ページのURL)
- [x] OGPを設定　(リンクのプレビューに表示される画像)
- [x] OGPを設定　(サイトの名前)
- [x] OGPを設定　(ページの説明文)
- [x] OGPを設定　(Twitterカードの表示形式をsummary_large_image)
＊Twitterカードの表示形式は、大きいものを実装(その他に、summary等あり)
## 補足事項
- [ ] 本番環境未実装の為に、デプロイ後に[このURLから確認を行う事](https://cards-dev.x.com/validator)
