### PR TITLE
画像投稿機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,6 @@ group :test do
 end
 
 gem "devise"
+
+# 画像アップロード用
+gem "carrierwave"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.3.2)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -110,10 +117,19 @@ GEM
       warden (~> 1.2.3)
     drb (2.2.1)
     erubi (1.12.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.13.1)
       rdoc (>= 4.0.0)
@@ -123,6 +139,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -133,6 +150,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.23.1)
     msgpack (1.7.2)
@@ -215,6 +233,9 @@ GEM
       railties (>= 5.2)
     rexml (3.3.3)
       strscan
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.3.2)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
@@ -228,6 +249,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -267,6 +289,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  carrierwave
   cssbundling-rails
   debug
   devise

--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -35,6 +35,6 @@ class AwardsController < ApplicationController
     end
 
     def award_params
-        params.require(:award).permit(:award_name, :title, :body)
+        params.require(:award).permit(:award_name, :title, :body, :image, :image_cache)
     end
 end

--- a/app/models/award.rb
+++ b/app/models/award.rb
@@ -1,4 +1,6 @@
 class Award < ApplicationRecord
+  mount_uploader :image, AwardImageUploader  # ここで紐づけを行います
+  
   validates :award_name, :title, :body, presence: true
   validates :award_name, length: { maximum: 255 }
   validates :title, :body, length: { maximum: 3000 }

--- a/app/uploaders/award_image_uploader.rb
+++ b/app/uploaders/award_image_uploader.rb
@@ -1,0 +1,52 @@
+class AwardImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url(*args)
+    'sample.png'
+    # For Rails 3.1+ asset pipeline compatibility:
+    # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  
+    #"/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  end
+
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/views/awards/_award.html.erb
+++ b/app/views/awards/_award.html.erb
@@ -3,7 +3,7 @@
   <p class="text-xs title-font font-medium text-gray-400">受賞名</p>
   <h2 class="text-3xl text-yellow-500 my-2"><%= award.award_name %></h2>
   <a class="block relative h-48 rounded overflow-hidden">
-    <%= image_tag 'sample.png', class: "object-cover object-center w-full h-full block" %>
+    <%= image_tag award.image.url, class: "object-cover object-center w-full h-full block" %>
   </a>
   <p class="text-xs title-font font-medium text-gray-500 my-2">ゲームタイトル</p>
   <p class="text-2xl text-yellow-500"><%= award.title %></p>

--- a/app/views/awards/new.html.erb
+++ b/app/views/awards/new.html.erb
@@ -17,6 +17,11 @@
           <%= f.label :body, "本文（好きに書いてね！）" %><br />
           <%= f.text_area :body, class: "textarea textarea-warning w-96 h-40" %>
         </div>
+        <div class="mt-3">
+          <%= f.label :image, "画像アップロード" %><br />
+          <%= f.file_field :image, class: "file-input file-input-bordered file-input-warning w-96", accept: 'image/*' %>
+          <%= f.hidden_field :image_cache %>
+        </div>
         <div class="my-2">
           <%= f.submit "登録", class: "btn btn-outline" %>
         </div>

--- a/app/views/awards/show.html.erb
+++ b/app/views/awards/show.html.erb
@@ -4,7 +4,7 @@
 <body>
     <section>
         <div class="mx-auto flex w-1/2 min-w-80 flex-col justify-center bg-white rounded-2xl shadow-xl shadow-gray-400/20 my-24 border-2" >
-          <%= image_tag 'sample.png', class: "aspect-video min-w-80 rounded-t-2xl object-cover object-center" %>
+          <%= image_tag @award.image.url, class: "aspect-video min-w-80 rounded-t-2xl object-cover object-center" %>
           <div class="p-6 text-center">
             <small class="text-gray-900">＜受賞名＞</small>
             <h1 class="text-4xl font-medium text-yellow-400 pb-2"><%= @award.award_name %></h1>


### PR DESCRIPTION
## 概要

https://gyazo.com/078768b0937e844be4dbcd329c92303f

## 実装内容
- [x] アップロード用のライブラリ(carrierwave)をインストール
- [x] docker内のshellでbundle installを実行
- [x] アップローダーを生成(AwardImageUploader)
- [x] 生成されたアップローダー内に、デフォルト画像と許可する拡張子の追加
- [x] awarbモデル内で、アップローダークラスとカラムの紐づけを記載
- [x] awards_controller内で、ストロングパラメーターに:image, :image_cacheを追加
- [x] app/views/awards/new.html.erbに、画像投稿フォームを追加
- [x] app/views/awards/_award.html.erbに、ローカル変数で画像URLの追加
- [x] app/views/awards/show.html.erbに、グローバル変数で画像URLの追加
- [x] .gitignoreに/public/uploadsを追加